### PR TITLE
Prepare Repo for Publishing on HACS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,3 +25,17 @@ jobs:
       - name: TDD
         run: |
           ./tdd
+
+  validate-hacs:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: HACS validation
+        uses: "hacs/action@main"
+        with:
+          category: "integration"
+
+  hassfest:
+    runs-on: "ubuntu-latest"
+    steps:
+        - uses: "actions/checkout@v4"
+        - uses: "home-assistant/actions/hassfest@master"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,9 @@ Pull requests are the best way to propose changes to the codebase.
 4. Test your contribution.
 5. Issue that pull request!
 
-## Any contributions you make will be under the MIT Software License
+## Any contributions you make will be under the BSD 3-Clause License
 
-In short, when you submit code changes, your submissions are understood to be under the same [MIT License](http://choosealicense.com/licenses/mit/) that covers the project. Feel free to contact the maintainers if that's a concern.
+In short, when you submit code changes, your submissions are understood to be under the same [BSD 3-Clause License](https://opensource.org/license/bsd-3-clause) that covers the project. Feel free to contact the maintainers if that's a concern.
 
 ## Report bugs using Github's [issues](../../issues)
 
@@ -60,4 +60,4 @@ Please write thorough unit tests using a Given-When-Then style, PRs without test
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under its MIT License.
+By contributing, you agree that your contributions will be licensed under its BSD 3-Clause License.

--- a/README.md
+++ b/README.md
@@ -4,19 +4,15 @@
 [![License][license-shield]](LICENSE)
 [![Community Forum][forum-shield]][forum]
 
-_Integration to integrate with [GE Appliances][ge_appliances]._
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=GE+Appliances&category=Integration&repository=https%3A%2F%2Fgithub.com%2Fgeappliances%2Fhacs-integration)
 
-**This integration will set up the following platforms.**
+_Integration to integrate with [GE Appliances](https://www.geappliances.com/)._
 
-Platform | Description
--- | --
-`binary_sensor` | Show something `True` or `False`.
-`sensor` | Show info from blueprint API.
-`switch` | Switch something `True` or `False`.
+This integration will automatically use the [Appliance API](https://github.com/geappliances/public-appliance-api-documentation) to find public ERDs on an appliance and set up corresponding entities in Home Assistant. It is designed to be a "batteries-included" option for users who want to quickly and easily get their appliances talking to Home Assistant. Users wanting a more customized experience might be interested in [using YAML with the MQTT integration](https://github.com/geappliances/home-assistant-examples) to communicate with their appliances.
 
 ## Installation
 
-1. The preferred method of installing this integration is through the [Home Assistant Community Store][hacs]
+1. The preferred method of installing this integration is through the [Home Assistant Community Store][hacs].
 
 <!---->
 
@@ -28,21 +24,14 @@ Platform | Description
 1. Restart Home Assistant
 1. In the HA UI go to "Configuration" -> "Integrations" click "+" and search for "GE Appliances"
 
-## Configuration is done in the UI
-
-<!---->
-
 
 ## Contributions are welcome!
 
 If you want to contribute to this please read the [Contribution guidelines](CONTRIBUTING.md)
 
-***
-
-[ge_appliances]: https://www.geappliances.com/
 [forum-shield]: https://img.shields.io/badge/community-forum-brightgreen.svg?style=for-the-badge
 [forum]: https://community.home-assistant.io/
-[license-shield]: https://img.shields.io/github/license/geappliances/applcommon.ge-appliances-integration.svg?style=for-the-badge
-[releases-shield]: https://img.shields.io/github/release/geappliances/applcommon.ge-appliances-integration.svg?style=for-the-badge
-[releases]: https://github.com/geappliances/applcommon.ge-appliances-integration/releases
+[license-shield]: https://img.shields.io/github/license/geappliances/hacs-integration.svg?style=for-the-badge
+[releases-shield]: https://img.shields.io/github/release/geappliances/hacs-integration.svg?style=for-the-badge
+[releases]: https://github.com/geappliances/hacs-integration/releases
 [hacs]: https://www.hacs.xyz

--- a/custom_components/geappliances/manifest.json
+++ b/custom_components/geappliances/manifest.json
@@ -1,7 +1,9 @@
 {
   "domain": "geappliances",
   "name": "GE Appliances",
-  "codeowners": [],
+  "codeowners": [
+    "@geappliances/home-assistant"
+  ],
   "config_flow": true,
   "dependencies": [
     "mqtt"

--- a/custom_components/geappliances/manifest.json
+++ b/custom_components/geappliances/manifest.json
@@ -6,8 +6,8 @@
   "dependencies": [
     "mqtt"
   ],
-  "documentation": "https://github.com/geappliances/applcommon.ge-appliances-integration",
-  "issue_tracker": "https://github.com/geappliances/applcommon.ge-appliances-integration/issues",
+  "documentation": "https://github.com/geappliances/hacs-integration",
+  "issue_tracker": "https://github.com/geappliances/hacs-integration/issues",
   "iot_class": "local_push",
   "requirements": [
     "aiofiles==24.1.0"

--- a/custom_components/geappliances/manifest.json
+++ b/custom_components/geappliances/manifest.json
@@ -7,8 +7,8 @@
     "mqtt"
   ],
   "documentation": "https://github.com/geappliances/hacs-integration",
-  "issue_tracker": "https://github.com/geappliances/hacs-integration/issues",
   "iot_class": "local_push",
+  "issue_tracker": "https://github.com/geappliances/hacs-integration/issues",
   "requirements": [
     "aiofiles==24.1.0"
   ],

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
     "name": "GE Appliances",
     "hide_default_branch": false,
-    "homeassistant": "2024.6.0",
+    "homeassistant": "2025.4.0",
     "render_readme": true
 }


### PR DESCRIPTION
- Cleans up `README.md` and corrects bad license in `CONTRIBUTING.md`
- Updates `hacs.json` and `manifest.json`
- Adds `HACS` and `Hassfest` jobs to CI

### TODO
- [x] Add topics and description to repository
- [x] Wait for https://github.com/home-assistant/brands/pull/7546 to get merged