### PR TITLE
Fix bit masking and shifting in meta_erds

### DIFF
--- a/custom_components/geappliances/ha_compatibility/meta_erds.py
+++ b/custom_components/geappliances/ha_compatibility/meta_erds.py
@@ -336,10 +336,9 @@ class MetaErdCoordinator:
         """Return the bits from the bitfield for the specified ERD field."""
         offset = field_def["bits"]["offset"]
         size = field_def["bits"]["size"]
-        field_size = field_def["size"]
 
-        mask = (1 << size) - 1  # Mask for the lowest `size` bytes
-        mask = mask << ((field_size * 8) - offset - size)  # Move mask to match offset
-        masked = int.from_bytes(field_bytes) & mask
+        mask = (1 << size) - 1 # Mask for the lowest `size` bytes
+        mask = mask << offset # Move mask to match offset
+        masked = (int.from_bytes(field_bytes) & mask) >> offset
 
         return masked.to_bytes()

--- a/tests/test_meta_erds.py
+++ b/tests/test_meta_erds.py
@@ -418,7 +418,7 @@ class TestMetaErds:
     ) -> None:
         """Test the allowables are set by the associated ERD."""
         await given_the_erd_is_set_to(0x0003, "00", hass)
-        await given_the_erd_is_set_to(0x0009, "80", hass)
+        await given_the_erd_is_set_to(0x0009, "01", hass)
 
         await setting_the_select_should_raise_error(
             "select.test_select_test_select", "One", hass


### PR DESCRIPTION
Final fixes for https://github.com/geappliances/geappliances-integration/issues/29
Followup to https://github.com/geappliances/geappliances-integration/pull/30

The linked PR above fixed the bitshifting in every place except `meta_erds.py`. This fixes that last instance so the selectors for mode on my water heater work correctly. Tested locally on my HA instance.

Thanks for the original fix @ben-strehl!
